### PR TITLE
OSX support, minor fixes

### DIFF
--- a/eyefi-config.c
+++ b/eyefi-config.c
@@ -225,7 +225,7 @@ int nr_fresh_pages(int fd, int len)
 	int faults_before;
 	int faults_after;
 	char *addr;
-	int tmp;
+	int tmp = 0;
 	int i;
 
 	addr = mmap(NULL, len, PROT_READ, MAP_FILE|MAP_SHARED, fd, 0);

--- a/eyefi-config.h
+++ b/eyefi-config.h
@@ -66,6 +66,7 @@ extern int eyefi_printf(const char *fmt, ...);
  * These have to be created by the unix variants
  */
 extern int fd_flush(int);
+extern int fd_set_no_cache(int);
 
 /*
  * Do some kernel-style types to make

--- a/eyefi-freebsd.c
+++ b/eyefi-freebsd.c
@@ -7,6 +7,11 @@
 #include <unistd.h>
 #include <fcntl.h>
 
+int fd_set_no_cache(int fd)
+{
+	return -1; // not implemented
+}
+
 int fd_flush(int fd)
 {
 	int ret;

--- a/eyefi-linux.c
+++ b/eyefi-linux.c
@@ -54,6 +54,11 @@ static char *replace_escapes(char *str)
 	return str;
 }
 
+int fd_set_no_cache(int fd)
+{
+	return -1; // not implemented
+}
+
 int fd_flush(int fd)
 {
 	int ret;

--- a/eyefi-osx.c
+++ b/eyefi-osx.c
@@ -1,7 +1,98 @@
+#include <sys/param.h>
+#include <sys/ucred.h>
+#include <sys/mount.h>
+
+#include "eyefi-config.h"
+
+#include <unistd.h>
+#include <fcntl.h>
+
 
 int fd_set_no_cache(int fd)
 {
 	return fcntl(fd, F_NOCACHE, 1);
 }
 
+int fd_flush(int fd)
+{
+	int ret;
+	ret = fsync(fd);
+	if (ret)
+		perror("fsync() failed");
+	return ret;
+}
 
+
+#define LINEBUFSZ 1024
+char *locate_eyefi_mount(void)
+{
+	static char eyefi_mount[PATHNAME_MAX]; // PATH_MAX anyone?
+
+	if (strlen(eyefi_mount))
+		return &eyefi_mount[0];
+
+	int numfs;
+	int bufsize;
+	struct statfs * fsbuf;
+	int i;
+
+	if ((numfs = getfsstat(NULL, 0, MNT_WAIT)) < 0) {
+		debug_printf(2, "unable to obtain the number of file systems\n");
+		return(NULL);
+	}
+
+	bufsize = (long)numfs *sizeof(struct statfs);
+	if ((fsbuf = malloc(bufsize)) == NULL) {
+		debug_printf(2, "unable to allocate space for filesystem list\n");
+		return(NULL);
+	}
+
+	if (getfsstat(fsbuf, bufsize, MNT_WAIT) < 0) {
+		debug_printf(2, "unable to get the list of filesystems\n");
+		return(NULL);
+	}
+
+	for(i = 0; i < numfs; i++) {
+		if(fsbuf[i].f_type != 5) continue; // Not MSDOS
+
+		char *file = eyefi_file_on(REQM, fsbuf[i].f_mntonname);
+		debug_printf(2, "looking for EyeFi file here: '%s'\n", file);
+
+		struct stat statbuf;
+		int statret;
+		statret = stat(file, &statbuf);
+		free(file);
+		if (statret) {
+			debug_printf(2, "fs at: %s is not an Eye-Fi card, skipping...\n",
+						 eyefi_mount);
+			continue;
+		}
+
+		strcpy(&eyefi_mount[0], fsbuf[i].f_mntonname);
+		debug_printf(1, "located EyeFi card at: '%s'\n", eyefi_mount);
+		break;
+	}
+
+	if (strlen(eyefi_mount))
+		return &eyefi_mount[0];
+
+	debug_printf(0, "unable to locate Eye-Fi card\n");
+	if (eyefi_debug_level < 5) {
+		debug_printf(0, "Please check that your card is inserted and mounted\n");
+		debug_printf(0, "If you still have issues, please re-run with the '-d5' option and report the output\n");
+	} else {
+		debug_printf(0, "----------------------------------------------\n");
+		debug_printf(0, "Debug information:\n");
+	}
+	exit(1);
+	return NULL;
+}
+
+void eject_card(void)
+{
+	char cmd[PATHNAME_MAX];
+	sprintf(cmd, "umount '%s'", locate_eyefi_mount());
+	debug_printf(1, "ejecting card: '%s'\n", cmd);
+	system(cmd);
+	exit(0);
+}

--- a/eyefi-osx.c
+++ b/eyefi-osx.c
@@ -16,9 +16,11 @@ int fd_set_no_cache(int fd)
 int fd_flush(int fd)
 {
 	int ret;
-	ret = fsync(fd);
-	if (ret)
-		perror("fsync() failed");
+
+	ret = fcntl(fd, F_FULLFSYNC);
+	if (ret == -1)
+		perror("fcntl() failed");
+
 	return ret;
 }
 

--- a/eyefi-osx.c
+++ b/eyefi-osx.c
@@ -53,7 +53,7 @@ char *locate_eyefi_mount(void)
 	}
 
 	for(i = 0; i < numfs; i++) {
-		if(fsbuf[i].f_type != 5) continue; // Not MSDOS
+		if(strcasecmp(fsbuf[i].f_fstypename, "msdos") != 0) continue; // Not MSDOS
 
 		char *file = eyefi_file_on(REQM, fsbuf[i].f_mntonname);
 		debug_printf(2, "looking for EyeFi file here: '%s'\n", file);

--- a/eyefi-osx.c
+++ b/eyefi-osx.c
@@ -93,7 +93,7 @@ char *locate_eyefi_mount(void)
 void eject_card(void)
 {
 	char cmd[PATHNAME_MAX];
-	sprintf(cmd, "umount '%s'", locate_eyefi_mount());
+	sprintf(cmd, "diskutil unmount '%s'", locate_eyefi_mount());
 	debug_printf(1, "ejecting card: '%s'\n", cmd);
 	system(cmd);
 	exit(0);

--- a/eyefi-unix.c
+++ b/eyefi-unix.c
@@ -212,7 +212,7 @@ const char *__index_to_str(const char **array, int index, int array_size)
 }
 #define index_to_str(chr_array, index)	__index_to_str(chr_array, index, ARRAY_SIZE(chr_array))
 
-enum transfer_mode str_to_transfer_mode(char *mode_str)
+int str_to_transfer_mode(char *mode_str)
 {
 	return index_of_str(mode_str, transfer_mode_names);
 }
@@ -221,7 +221,7 @@ void handle_transfer_mode(char *arg)
 {
 	enum transfer_mode mode;
 	const char *mode_name;
-	enum transfer_mode new_mode;
+	int new_mode;
 	if (arg) {
 		new_mode = str_to_transfer_mode(arg);
 		if (new_mode == -1) {
@@ -235,7 +235,7 @@ void handle_transfer_mode(char *arg)
 			}
 			exit(1);
 		}
-		set_transfer_mode(new_mode);
+		set_transfer_mode((enum transfer_mode)new_mode);
 	}
 
 	mode = fetch_transfer_mode();

--- a/md5.c
+++ b/md5.c
@@ -286,7 +286,7 @@ void MD5Final(unsigned char digest[16], struct MD5Context *ctx)
     MD5Transform(ctx->buf, (u32 *) ctx->in);
     byteReverse((unsigned char *) ctx->buf, 4);
     os_memcpy(digest, ctx->buf, 16);
-    os_memset(ctx, 0, sizeof(ctx));	/* In case it's sensitive */
+    os_memset(ctx, 0, sizeof(*ctx));	/* In case it's sensitive */
 }
 
 /* The four core functions - F1 is optimized somewhat */


### PR DESCRIPTION
Investigating more, I found that fcntl(fd, NO_CACHE, 1) looks like it works all by itself on OSX, I just had to make sure to skip the pagefault-counting code so it doesn't loop forever. So here is a new pull request that's a bit cleaner than #5